### PR TITLE
feat: Add forceMultiPage feature flag for reliable multi-page extraction

### DIFF
--- a/api/evidence-first-bridge.js
+++ b/api/evidence-first-bridge.js
@@ -343,6 +343,16 @@ Return ONLY the JSON response - no explanations or additional text.`;
     const url = (params.url || '').toLowerCase();
     const htmlLower = htmlContent.toLowerCase();
     
+    // Check for forceMultiPage flag first - highest priority
+    if (params.forceMultiPage === true) {
+      return {
+        required: true,
+        reason: 'force_multipage_enabled',
+        confidence: 1.0,
+        forced: true
+      };
+    }
+    
     // Explicit multi-page keywords in user request
     const explicitKeywords = [
       'all pages', 'entire site', 'full site', 'navigate through', 

--- a/api/lambda.js
+++ b/api/lambda.js
@@ -204,7 +204,8 @@ async function handleExtract(method, body, headers) {
           },
           postProcessing: params.postProcessing || null,
           formats: params.formats || ['structured'],
-          UNIFIED_EXTRACTOR_ENABLED: params.UNIFIED_EXTRACTOR_ENABLED
+          UNIFIED_EXTRACTOR_ENABLED: params.UNIFIED_EXTRACTOR_ENABLED,
+          forceMultiPage: params.forceMultiPage || false
         };
         
         // Process with unified extractor system
@@ -402,6 +403,7 @@ exports.handler = async (event) => {
               extractionInstructions: params.prompt || params.input,
               formats: aiResult.formats || ['structured'],
               UNIFIED_EXTRACTOR_ENABLED: params.UNIFIED_EXTRACTOR_ENABLED,
+              forceMultiPage: params.forceMultiPage || false,
               ...aiResult.params
             };
             

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -159,6 +159,7 @@ function App() {
   const [aiMode, setAiMode] = useState(false);
   const [aiProcessing, setAiProcessing] = useState(false);
   const [useUnifiedExtractor, setUseUnifiedExtractor] = useState(false);
+  const [forceMultiPage, setForceMultiPage] = useState(false);
   
   // Options state - always visible
   const [includeHtml, setIncludeHtml] = useState(true);
@@ -230,7 +231,8 @@ function App() {
           body: JSON.stringify({
             prompt: url,
             autoExecute: true,
-            UNIFIED_EXTRACTOR_ENABLED: useUnifiedExtractor
+            UNIFIED_EXTRACTOR_ENABLED: useUnifiedExtractor,
+            forceMultiPage: forceMultiPage
           })
         });
         
@@ -311,7 +313,8 @@ function App() {
             body: JSON.stringify({
               prompt: fullUrl,
               autoExecute: false, // Get the structured params but don't auto-execute
-              UNIFIED_EXTRACTOR_ENABLED: useUnifiedExtractor
+              UNIFIED_EXTRACTOR_ENABLED: useUnifiedExtractor,
+              forceMultiPage: forceMultiPage
             }),
           });
           
@@ -377,6 +380,7 @@ function App() {
         type: mode,
         useEvidenceFirst: true, // Enable evidence-first processing
         UNIFIED_EXTRACTOR_ENABLED: useUnifiedExtractor, // Add unified extractor flag
+        forceMultiPage: forceMultiPage, // Add force multi-page flag
         ...extractedParams // This now includes extractionInstructions, outputSchema, postProcessing from AI
       };
       
@@ -1089,6 +1093,35 @@ Examples:
                       </p>
                     </div>
                   )}
+
+                  {/* Force Multi-Page Option - Only visible when Unified Extractor is enabled */}
+                  {useUnifiedExtractor && (
+                    <>
+                      <div className="flex items-center justify-between">
+                        <Label htmlFor="force-multipage" className="text-sm font-medium">
+                          Force Multi-Page Extraction
+                        </Label>
+                        <Switch
+                          id="force-multipage"
+                          checked={forceMultiPage}
+                          onCheckedChange={setForceMultiPage}
+                        />
+                      </div>
+                      {forceMultiPage && (
+                        <div className="bg-gradient-to-r from-blue-50 to-cyan-50 border border-blue-200 rounded-lg p-3">
+                          <div className="flex items-center gap-2 mb-1">
+                            <Map className="w-4 h-4 text-blue-600" />
+                            <span className="text-xs font-semibold text-blue-900">
+                              Multi-Page Mode Enabled
+                            </span>
+                          </div>
+                          <p className="text-xs text-blue-700">
+                            Will crawl and extract from multiple pages for more comprehensive results. Recommended for news sites and dynamic content.
+                          </p>
+                        </div>
+                      )}
+                    </>
+                  )}
                   <div className="border-t pt-4" />
                   {mode === 'scrape' && (
                     <>
@@ -1280,7 +1313,8 @@ Examples:
                       url: url || 'example.com', 
                       type: mode, 
                       format,
-                      ...(useUnifiedExtractor && { UNIFIED_EXTRACTOR_ENABLED: true })
+                      ...(useUnifiedExtractor && { UNIFIED_EXTRACTOR_ENABLED: true }),
+                      ...(forceMultiPage && { forceMultiPage: true })
                     }, null, 2)}'
                   </div>
                   <Button variant="outline" size="sm" className="mt-3 w-full">

--- a/test-force-multipage.sh
+++ b/test-force-multipage.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+echo "Testing Force Multi-Page Feature"
+echo "================================"
+
+API_URL="https://gxi4vg8gla.execute-api.us-west-2.amazonaws.com/dev"
+API_KEY="test-key-123"
+
+echo ""
+echo "Test 1: Standard extraction (should use single-page)"
+echo "------------------------------------------------------"
+curl -X POST "$API_URL/api/extract" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $API_KEY" \
+  -d '{
+    "url": "https://nytimes.com",
+    "extractionInstructions": "extract top 5 headlines",
+    "UNIFIED_EXTRACTOR_ENABLED": true
+  }' | jq '.result.metadata.processingMethod'
+
+echo ""
+echo "Test 2: Force Multi-Page extraction (should use navigation-aware)"
+echo "-----------------------------------------------------------------"
+curl -X POST "$API_URL/api/extract" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $API_KEY" \
+  -d '{
+    "url": "https://nytimes.com",
+    "extractionInstructions": "extract top 5 headlines",
+    "UNIFIED_EXTRACTOR_ENABLED": true,
+    "forceMultiPage": true
+  }' | jq '.result.metadata.processingMethod'
+
+echo ""
+echo "Test 3: Force Multi-Page with AI mode"
+echo "--------------------------------------"
+curl -X POST "$API_URL/api/ai/process" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $API_KEY" \
+  -d '{
+    "prompt": "get the top 5 headlines from nytimes.com",
+    "autoExecute": true,
+    "UNIFIED_EXTRACTOR_ENABLED": true,
+    "forceMultiPage": true
+  }' | jq '.result.metadata'


### PR DESCRIPTION
## Summary
- Adds `forceMultiPage` parameter to force navigation-aware extraction
- Provides UI toggle in frontend when Unified Extractor is enabled
- Solves issue where single-page extraction returns dummy data for dynamic sites

## Problem
When extracting from news sites like NYTimes, the system sometimes uses single-page extraction which causes GPT-4o to generate dummy/placeholder headlines instead of extracting real content. This happens when pagination indicators aren't detected in the initial HTML fetch.

## Solution
Added a `forceMultiPage` boolean flag that bypasses automatic detection and forces the system to use navigation-aware multi-page extraction. This ensures real content is extracted from dynamic sites.

## Changes
### Backend
- **api/evidence-first-bridge.js**: Check `forceMultiPage` flag with highest priority in `shouldUseMultiPageExtraction()`
- **api/lambda.js**: Pass through `forceMultiPage` parameter in both `/api/extract` and `/api/ai/process` endpoints

### Frontend
- **packages/frontend/src/App.tsx**: 
  - Added `forceMultiPage` state and toggle UI
  - Toggle appears only when Unified Extractor is enabled
  - Shows visual feedback with "Multi-Page Mode Enabled"
  - Updates all API calls to include the parameter
  - Updates curl example to show the flag

### Testing
- **test-force-multipage.sh**: Test script to verify the feature works correctly

## Test Plan
- [ ] Deploy to dev environment
- [ ] Test standard extraction without flag (should use single-page when appropriate)
- [ ] Test with `forceMultiPage: true` (should always use multi-page extraction)
- [ ] Verify NYTimes Trump headlines return real data with flag enabled
- [ ] Test UI toggle functionality in frontend
- [ ] Verify curl examples work as documented

🤖 Generated with [Claude Code](https://claude.ai/code)